### PR TITLE
Show end date for all-day events that span multiple days

### DIFF
--- a/frontend/src/components/NextUpListItem.vue
+++ b/frontend/src/components/NextUpListItem.vue
@@ -35,14 +35,25 @@
               handler: function () {
                 if (this.calendarItem.allDayEvent) {
                   // Show the date without the time (which is always 00:00)
-                  this.dateText = this.$moment(this.calendarItem.startDate).calendar({
+                  let allDayFormat = {
                     sameDay: '[Heute]',
                     nextDay: '[Morgen]',
                     nextWeek: 'dddd',
                     lastDay: '[Gestern]',
                     lastWeek: '[Letzten] dddd',
                     sameElse: 'L'
-                  })
+                  }
+                  this.dateText = this.$moment(this.calendarItem.startDate).calendar(allDayFormat)
+
+                  // Subtract one second, because the end is at 00:00 of the following day
+                  const endDate = this.calendarItem.endDate - 1000
+                  const endDateText = this.$moment(endDate).calendar(allDayFormat)
+
+                  // Is it a multi-day event?
+                  if (this.dateText !== endDateText) {
+                    this.dateText = `${this.dateText} - ${endDateText}`
+                  }
+
                 } else {
                   this.dateText = this.$moment(this.calendarItem.startDate).calendar()
                 }


### PR DESCRIPTION
Until now, the next-up list would only show the start date on an event, even if it spanned multiple days.

<img width="808" alt="Bildschirmfoto 2023-06-18 um 13 48 27" src="https://github.com/alarmdisplay/display/assets/1263052/655581aa-cbe9-4a4a-8fae-6353e1db3d89">
