### PR TITLE
fix(config): Fail CI if Codecov upload fails

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -53,6 +53,7 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
       with:
+        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ${{github.workspace}}/server/coverage
         flags: server


### PR DESCRIPTION
`fail_ci_if_error` is false by default