### PR TITLE
refactor!: remove API prefix

### DIFF
--- a/console/src/store/services/announcements.js
+++ b/console/src/store/services/announcements.js
@@ -25,7 +25,7 @@ class Announcement extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/announcements'
+const servicePath = 'announcements'
 const servicePlugin = makeServicePlugin({
   Model: Announcement,
   service: feathersClient.service(servicePath),

--- a/console/src/store/services/api-keys.js
+++ b/console/src/store/services/api-keys.js
@@ -11,7 +11,7 @@ class ApiKey extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/api-keys'
+const servicePath = 'api-keys'
 const servicePlugin = makeServicePlugin({
   Model: ApiKey,
   service: feathersClient.service(servicePath),

--- a/console/src/store/services/content-slots.js
+++ b/console/src/store/services/content-slots.js
@@ -16,7 +16,7 @@ class ContentSlot extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/content-slots'
+const servicePath = 'content-slots'
 const servicePlugin = makeServicePlugin({
   Model: ContentSlot,
   service: feathersClient.service(servicePath),

--- a/console/src/store/services/displays.js
+++ b/console/src/store/services/displays.js
@@ -39,7 +39,7 @@ class Display extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/displays'
+const servicePath = 'displays'
 const servicePlugin = makeServicePlugin({
   Model: Display,
   service: feathersClient.service(servicePath),

--- a/console/src/store/services/incidents.js
+++ b/console/src/store/services/incidents.js
@@ -30,7 +30,7 @@ class Incident extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/incidents'
+const servicePath = 'incidents'
 const servicePlugin = makeServicePlugin({
   Model: Incident,
   service: feathersClient.service(servicePath),

--- a/console/src/store/services/key-requests.js
+++ b/console/src/store/services/key-requests.js
@@ -13,7 +13,7 @@ class KeyRequest extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/key-requests'
+const servicePath = 'key-requests'
 const servicePlugin = makeServicePlugin({
   Model: KeyRequest,
   service: feathersClient.service(servicePath),

--- a/console/src/store/services/locations.js
+++ b/console/src/store/services/locations.js
@@ -19,7 +19,7 @@ class Location extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/locations'
+const servicePath = 'locations'
 const servicePlugin = makeServicePlugin({
   Model: Location,
   service: feathersClient.service(servicePath),

--- a/console/src/store/services/settings.js
+++ b/console/src/store/services/settings.js
@@ -12,7 +12,7 @@ class Setting extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/settings'
+const servicePath = 'settings'
 const servicePlugin = makeServicePlugin({
   Model: Setting,
   idField: 'key',

--- a/console/src/store/services/views.js
+++ b/console/src/store/services/views.js
@@ -42,7 +42,7 @@ class View extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/views'
+const servicePath = 'views'
 const servicePlugin = makeServicePlugin({
   Model: View,
   service: feathersClient.service(servicePath),

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -49,7 +49,7 @@ export default {
           await this.$store.dispatch('displays/get', 'self')
         } catch (reason) {
           console.error('Error while trying to get own Display ID:', reason.message);
-          feathersClient.io.emit('create', 'api/v1/key-requests', {}, (error, result) => {
+          feathersClient.io.emit('create', 'key-requests', {}, (error, result) => {
             if (error) {
               console.error('Could not request API key:', error)
               return

--- a/frontend/src/store/services/announcements.js
+++ b/frontend/src/store/services/announcements.js
@@ -29,7 +29,7 @@ class Announcement extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/announcements'
+const servicePath = 'announcements'
 const servicePlugin = makeServicePlugin({
   Model: Announcement,
   service: feathersClient.service(servicePath),

--- a/frontend/src/store/services/content-slots.js
+++ b/frontend/src/store/services/content-slots.js
@@ -19,7 +19,7 @@ class ContentSlot extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/content-slots'
+const servicePath = 'content-slots'
 const servicePlugin = makeServicePlugin({
   Model: ContentSlot,
   service: feathersClient.service(servicePath),

--- a/frontend/src/store/services/displays.js
+++ b/frontend/src/store/services/displays.js
@@ -44,7 +44,7 @@ class Display extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/displays'
+const servicePath = 'displays'
 const servicePlugin = makeServicePlugin({
   Model: Display,
   getters: {

--- a/frontend/src/store/services/incidents.js
+++ b/frontend/src/store/services/incidents.js
@@ -57,7 +57,7 @@ class Incident extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/incidents'
+const servicePath = 'incidents'
 const servicePlugin = makeServicePlugin({
   Model: Incident,
   service: feathersClient.service(servicePath),

--- a/frontend/src/store/services/key-requests.js
+++ b/frontend/src/store/services/key-requests.js
@@ -13,7 +13,7 @@ class KeyRequest extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/key-requests'
+const servicePath = 'key-requests'
 const servicePlugin = makeServicePlugin({
   Model: KeyRequest,
   service: feathersClient.service(servicePath),

--- a/frontend/src/store/services/locations.js
+++ b/frontend/src/store/services/locations.js
@@ -23,7 +23,7 @@ class Location extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/locations'
+const servicePath = 'locations'
 const servicePlugin = makeServicePlugin({
   Model: Location,
   service: feathersClient.service(servicePath),

--- a/frontend/src/store/services/settings.js
+++ b/frontend/src/store/services/settings.js
@@ -11,7 +11,7 @@ class Setting extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/settings'
+const servicePath = 'settings'
 const servicePlugin = makeServicePlugin({
   Model: Setting,
   idField: 'key',

--- a/frontend/src/store/services/views.js
+++ b/frontend/src/store/services/views.js
@@ -46,7 +46,7 @@ class View extends BaseModel {
   }
 }
 
-const servicePath = 'api/v1/views'
+const servicePath = 'views'
 const servicePlugin = makeServicePlugin({
   Model: View,
   service: feathersClient.service(servicePath),

--- a/frontend/src/store/socket.js
+++ b/frontend/src/store/socket.js
@@ -52,7 +52,7 @@ export function createSocketPlugin (socket) {
         socket.on('error', (err) => {
             console.error('Socket error', err)
         })
-        socket.on('api/v1/key-requests patched', (data) => {
+        socket.on('key-requests patched', (data) => {
             let keyRequestId = store.state.socket.keyRequestId;
             if (!keyRequestId) {
                 console.error('No key request active, this update should not have been sent here')
@@ -73,7 +73,7 @@ export function createSocketPlugin (socket) {
         })
 
         // If 'our' display is deleted on the backend, reload the app to restart the onboarding
-        socket.on('api/v1/displays removed', (data) => {
+        socket.on('displays removed', (data) => {
             let ownDisplayId = store.state.ownDisplayId;
             if (ownDisplayId && ownDisplayId === data.id) {
                 location.reload()

--- a/server/src/auth-strategies/api-key.strategy.ts
+++ b/server/src/auth-strategies/api-key.strategy.ts
@@ -30,7 +30,7 @@ export class ApiKeyStrategy extends AuthenticationBaseStrategy {
     if (!this.app) {
       throw new Error('Cannot access main application');
     }
-    const ApiKeyService = this.app.service('api/v1/api-keys');
+    const ApiKeyService = this.app.service('api-keys');
     let storedApiKey;
     try {
       storedApiKey = await ApiKeyService.get(id);
@@ -51,7 +51,7 @@ export class ApiKeyStrategy extends AuthenticationBaseStrategy {
 
     // If the API key belongs to a Display
     if (storedApiKey.displayId) {
-      const DisplayService = this.app.service('api/v1/displays');
+      const DisplayService = this.app.service('displays');
       try {
         result.display = await DisplayService.get(storedApiKey.displayId, params);
       } catch {

--- a/server/src/channels.ts
+++ b/server/src/channels.ts
@@ -99,7 +99,7 @@ export default function(app: Application): void {
     if (pendingConnections.has(connection)) {
       const clientId = pendingConnections.get(connection);
       // Remove any key request, that came through this connection
-      await app.service('api/v1/key-requests').remove(null, { query: { requestId: clientId } });
+      await app.service('key-requests').remove(null, { query: { requestId: clientId } });
       pendingConnections.delete(connection);
     }
   });
@@ -109,21 +109,21 @@ export default function(app: Application): void {
     // Here you can add event publishers to channels set up in `channels.js`
     // To publish only for a specific event use `app.publish(eventname, () => {})`
 
-    logger.debug('Publishing all events to all authenticated users. See `channels.js` and https://docs.feathersjs.com/api/channels.html for more information.');  
+    logger.debug('Publishing all events to all authenticated users. See `channels.js` and https://docs.feathersjs.com/api/channels.html for more information.');
 
     // e.g. to publish all service events to all authenticated users use
     return app.channel('authenticated');
   });
 
   // Send the patched event only to the affected connection, because it contains the key
-  app.service('api/v1/key-requests').publish('patched', (data: KeyRequestData) => {
+  app.service('key-requests').publish('patched', (data: KeyRequestData) => {
     return [
       app.channel(`connections/${data.requestId}`)
     ];
   });
 
   // Send all other events about key requests also to the affected connection, not only the authenticated ones
-  app.service('api/v1/key-requests').publish((data: KeyRequestData) => {
+  app.service('key-requests').publish((data: KeyRequestData) => {
     return [
       app.channel('authenticated'),
       app.channel(`connections/${data.requestId}`)

--- a/server/src/services/announcements/announcements.service.ts
+++ b/server/src/services/announcements/announcements.service.ts
@@ -1,4 +1,4 @@
-// Initializes the `announcements` service on path `/api/v1/announcements`
+// Initializes the `announcements` service on path `/announcements`
 import { ServiceAddons } from '@feathersjs/feathers';
 import { Application } from '../../declarations';
 import { Announcements } from './announcements.class';
@@ -8,7 +8,7 @@ import hooks from './announcements.hooks';
 // Add this service to the service type index
 declare module '../../declarations' {
   interface ServiceTypes {
-    'api/v1/announcements': Announcements & ServiceAddons<any>;
+    'announcements': Announcements & ServiceAddons<any>;
   }
 
   interface AnnouncementData {
@@ -28,10 +28,10 @@ export default function (app: Application): void {
   };
 
   // Initialize our service with any options it requires
-  app.use('/api/v1/announcements', new Announcements(options, app));
+  app.use('/announcements', new Announcements(options, app));
 
   // Get our initialized service so that we can register hooks
-  const service = app.service('api/v1/announcements');
+  const service = app.service('announcements');
 
   service.hooks(hooks);
 }

--- a/server/src/services/api-keys/api-keys.service.ts
+++ b/server/src/services/api-keys/api-keys.service.ts
@@ -1,4 +1,4 @@
-// Initializes the `api-keys` service on path `/api/v1/api-keys`
+// Initializes the `api-keys` service on path `/api-keys`
 import { ServiceAddons } from '@feathersjs/feathers';
 import { Application } from '../../declarations';
 import { ApiKeys } from './api-keys.class';
@@ -8,7 +8,7 @@ import hooks from './api-keys.hooks';
 // Add this service to the service type index
 declare module '../../declarations' {
   interface ServiceTypes {
-    'api/v1/api-keys': ApiKeys & ServiceAddons<any>;
+    'api-keys': ApiKeys & ServiceAddons<any>;
   }
 }
 
@@ -19,10 +19,10 @@ export default function (app: Application): void {
   };
 
   // Initialize our service with any options it requires
-  app.use('/api/v1/api-keys', new ApiKeys(options, app));
+  app.use('/api-keys', new ApiKeys(options, app));
 
   // Get our initialized service so that we can register hooks
-  const service = app.service('api/v1/api-keys');
+  const service = app.service('api-keys');
 
   service.hooks(hooks);
 }

--- a/server/src/services/content-slots/content-slots.service.ts
+++ b/server/src/services/content-slots/content-slots.service.ts
@@ -1,4 +1,4 @@
-// Initializes the `content-slots` service on path `/api/v1/content-slots`
+// Initializes the `content-slots` service on path `/content-slots`
 import { ServiceAddons } from '@feathersjs/feathers';
 import { Application } from '../../declarations';
 import { ContentSlots } from './content-slots.class';
@@ -8,7 +8,7 @@ import hooks from './content-slots.hooks';
 // Add this service to the service type index
 declare module '../../declarations' {
   interface ServiceTypes {
-    'api/v1/content-slots': ContentSlots & ServiceAddons<any>;
+    'content-slots': ContentSlots & ServiceAddons<any>;
   }
 
   interface ContentSlotData {
@@ -31,10 +31,10 @@ export default function (app: Application): void {
   };
 
   // Initialize our service with any options it requires
-  app.use('/api/v1/content-slots', new ContentSlots(options, app));
+  app.use('/content-slots', new ContentSlots(options, app));
 
   // Get our initialized service so that we can register hooks
-  const service = app.service('api/v1/content-slots');
+  const service = app.service('content-slots');
 
   service.hooks(hooks);
 }

--- a/server/src/services/displays/displays.class.ts
+++ b/server/src/services/displays/displays.class.ts
@@ -38,14 +38,14 @@ export class Displays extends Service<DisplayData> {
       await this.diffViews(id as number, data.views);
     } else {
       // The views are intentionally left empty, remove all existing ones
-      await this.app.service('api/v1/views').remove(null, { query: { displayId: id } });
+      await this.app.service('views').remove(null, { query: { displayId: id } });
     }
 
     return await super._update(id, data, params);
   }
 
   private async diffViews(id: number, submittedViews: ViewData[] | undefined) {
-    const ViewsService = this.app.service('api/v1/views');
+    const ViewsService = this.app.service('views');
 
     if (submittedViews && submittedViews.length === 0) {
       // Shortcut: No views should be assigned, so delete any that belong to this display

--- a/server/src/services/displays/displays.hooks.ts
+++ b/server/src/services/displays/displays.hooks.ts
@@ -8,7 +8,7 @@ const { authenticate } = authentication.hooks;
 
 const populateOptions = {
   include: {
-    service: 'api/v1/views',
+    service: 'views',
     nameAs: 'views',
     keyHere: 'id',
     keyThere: 'displayId',

--- a/server/src/services/displays/displays.service.ts
+++ b/server/src/services/displays/displays.service.ts
@@ -1,4 +1,4 @@
-// Initializes the `displays` service on path `/api/v1/displays`
+// Initializes the `displays` service on path `/displays`
 import { ServiceAddons } from '@feathersjs/feathers';
 import { Application } from '../../declarations';
 import { Displays } from './displays.class';
@@ -8,7 +8,7 @@ import hooks from './displays.hooks';
 // Add this service to the service type index
 declare module '../../declarations' {
   interface ServiceTypes {
-    'api/v1/displays': Displays & ServiceAddons<any>;
+    'displays': Displays & ServiceAddons<any>;
   }
 
   interface DisplayData {
@@ -28,10 +28,10 @@ export default function (app: Application): void {
   };
 
   // Initialize our service with any options it requires
-  app.use('/api/v1/displays', new Displays(options, app));
+  app.use('/displays', new Displays(options, app));
 
   // Get our initialized service so that we can register hooks
-  const service = app.service('api/v1/displays');
+  const service = app.service('displays');
 
   service.hooks(hooks);
 }

--- a/server/src/services/hub-connector/services/incidents.class.ts
+++ b/server/src/services/hub-connector/services/incidents.class.ts
@@ -40,7 +40,7 @@ export default class IncidentsWatcher {
       delete locationData.id;
     }
 
-    const newIncident = await this.app.service('api/v1/incidents').create({
+    const newIncident = await this.app.service('incidents').create({
       time: new Date(data.time),
       sender: data.sender,
       ref: data.ref,
@@ -59,7 +59,7 @@ export default class IncidentsWatcher {
 
   onUpdated = async (data: RemoteIncidentData): Promise<void> => {
     logger.debug('Incident updated/patched', data);
-    const service = this.app.service('api/v1/incidents');
+    const service = this.app.service('incidents');
     const incidents = await service.find({ query: { hubIncidentId: data.id }, paginate: false }) as IncidentData[];
     if (incidents.length === 0) {
       // We have not seen this incident before, pretend that it just got created
@@ -84,6 +84,6 @@ export default class IncidentsWatcher {
 
   onRemoved = async (data: RemoteIncidentData): Promise<void> => {
     logger.debug('Incident removed', data);
-    await this.app.service('api/v1/incidents').remove(null, { query: { hubIncidentId: data.id } });
+    await this.app.service('incidents').remove(null, { query: { hubIncidentId: data.id } });
   };
 }

--- a/server/src/services/hub-connector/services/locations.class.ts
+++ b/server/src/services/hub-connector/services/locations.class.ts
@@ -50,13 +50,13 @@ export default class LocationsWatcher {
       newData.incidentId = incidentId;
     }
 
-    const newLocation = await this.app.service('api/v1/locations').create(newData) as LocationData;
+    const newLocation = await this.app.service('locations').create(newData) as LocationData;
     logger.debug('Location mirrored (remote: %d, local: %d)', data.id, newLocation.id);
   };
 
   onUpdated = async (data: RemoteLocationData): Promise<void> => {
     logger.debug('Location updated/patched', data);
-    const service = this.app.service('api/v1/locations');
+    const service = this.app.service('locations');
     const locations = await service.find({ query: { hubLocationId: data.id }, paginate: false }) as (LocationData & { id : number })[];
     if (locations.length === 0) {
       // We have not seen this Location before, pretend that it just got created
@@ -84,7 +84,7 @@ export default class LocationsWatcher {
 
   onRemoved = async (data: RemoteLocationData): Promise<void> => {
     logger.debug('Location removed', data);
-    await this.app.service('api/v1/locations').remove(null, { query: { hubLocationId: data.id } });
+    await this.app.service('locations').remove(null, { query: { hubLocationId: data.id } });
   };
 
   /**
@@ -93,7 +93,7 @@ export default class LocationsWatcher {
    * @param id
    */
   private translateIncidentId = async (id: number): Promise<number | undefined> => {
-    const incidents = await this.app.service('api/v1/incidents').find({ query: { hubIncidentId: id }, paginate: false }) as IncidentData[];
+    const incidents = await this.app.service('incidents').find({ query: { hubIncidentId: id }, paginate: false }) as IncidentData[];
     if (incidents.length) {
       return incidents[0].id;
     }

--- a/server/src/services/incidents/incidents.hooks.ts
+++ b/server/src/services/incidents/incidents.hooks.ts
@@ -11,7 +11,7 @@ const { authenticate } = authentication.hooks;
 
 const populateOptions = {
   include: {
-    service: 'api/v1/locations',
+    service: 'locations',
     nameAs: 'location',
     keyHere: 'id',
     keyThere: 'incidentId',
@@ -53,7 +53,7 @@ export default {
 
 async function includeAssociations(context: HookContext): Promise<HookContext> {
   if (context.data.location) {
-    const LocationService = context.app.service('api/v1/locations');
+    const LocationService = context.app.service('locations');
     context.params.sequelize = {
       include: [{ model: LocationService.Model }]
     };

--- a/server/src/services/incidents/incidents.service.ts
+++ b/server/src/services/incidents/incidents.service.ts
@@ -1,4 +1,4 @@
-// Initializes the `incidents` service on path `/api/v1/incidents`
+// Initializes the `incidents` service on path `/incidents`
 import { ServiceAddons } from '@feathersjs/feathers';
 import { Application } from '../../declarations';
 import { Incidents } from './incidents.class';
@@ -8,7 +8,7 @@ import hooks from './incidents.hooks';
 // Add this service to the service type index
 declare module '../../declarations' {
   interface ServiceTypes {
-    'api/v1/incidents': Incidents & ServiceAddons<any>;
+    'incidents': Incidents & ServiceAddons<any>;
   }
 
   interface IncidentData {
@@ -36,10 +36,10 @@ export default function (app: Application): void {
   };
 
   // Initialize our service with any options it requires
-  app.use('/api/v1/incidents', new Incidents(options, app));
+  app.use('/incidents', new Incidents(options, app));
 
   // Get our initialized service so that we can register hooks
-  const service = app.service('api/v1/incidents');
+  const service = app.service('incidents');
 
   service.hooks(hooks);
 }

--- a/server/src/services/key-requests/key-requests.class.ts
+++ b/server/src/services/key-requests/key-requests.class.ts
@@ -38,11 +38,11 @@ export class KeyRequests extends Service<KeyRequestData> {
     const existingRecord = await this.get(id);
     // If the key request gets granted, create an API key, connected to a new Display
     if (!existingRecord.granted && data.granted === true) {
-      const newDisplay = await this.app.service('api/v1/displays').create({
+      const newDisplay = await this.app.service('displays').create({
         name: data.name || 'Neues Display',
         active: true
       }) as DisplayData;
-      const newApiKey = await this.app.service('api/v1/api-keys').create({
+      const newApiKey = await this.app.service('api-keys').create({
         name: newDisplay.name,
         displayId: newDisplay.id
       });

--- a/server/src/services/key-requests/key-requests.service.ts
+++ b/server/src/services/key-requests/key-requests.service.ts
@@ -1,4 +1,4 @@
-// Initializes the `key-requests` service on path `/api/v1/key-requests`
+// Initializes the `key-requests` service on path `/key-requests`
 import { ServiceAddons } from '@feathersjs/feathers';
 import { Application } from '../../declarations';
 import { KeyRequests } from './key-requests.class';
@@ -7,7 +7,7 @@ import hooks from './key-requests.hooks';
 // Add this service to the service type index
 declare module '../../declarations' {
   interface ServiceTypes {
-    'api/v1/key-requests': KeyRequests & ServiceAddons<any>;
+    'key-requests': KeyRequests & ServiceAddons<any>;
   }
 
   interface KeyRequestData {
@@ -25,10 +25,10 @@ export default function (app: Application): void {
   };
 
   // Initialize our service with any options it requires
-  app.use('/api/v1/key-requests', new KeyRequests(options, app));
+  app.use('/key-requests', new KeyRequests(options, app));
 
   // Get our initialized service so that we can register hooks
-  const service = app.service('api/v1/key-requests');
+  const service = app.service('key-requests');
 
   service.hooks(hooks);
 }

--- a/server/src/services/locations/locations.service.ts
+++ b/server/src/services/locations/locations.service.ts
@@ -1,4 +1,4 @@
-// Initializes the `locations` service on path `/api/v1/locations`
+// Initializes the `locations` service on path `/locations`
 import { ServiceAddons } from '@feathersjs/feathers';
 import { Application } from '../../declarations';
 import { Locations } from './locations.class';
@@ -8,7 +8,7 @@ import hooks from './locations.hooks';
 // Add this service to the service type index
 declare module '../../declarations' {
   interface ServiceTypes {
-    'api/v1/locations': Locations & ServiceAddons<any>;
+    'locations': Locations & ServiceAddons<any>;
   }
 
   interface LocationData {
@@ -35,10 +35,10 @@ export default function (app: Application): void {
   };
 
   // Initialize our service with any options it requires
-  app.use('/api/v1/locations', new Locations(options, app));
+  app.use('/locations', new Locations(options, app));
 
   // Get our initialized service so that we can register hooks
-  const service = app.service('api/v1/locations');
+  const service = app.service('locations');
 
   service.hooks(hooks);
 }

--- a/server/src/services/settings/settings.service.ts
+++ b/server/src/services/settings/settings.service.ts
@@ -1,4 +1,4 @@
-// Initializes the `settings` service on path `/api/v1/settings`
+// Initializes the `settings` service on path `/settings`
 import { ServiceAddons } from '@feathersjs/feathers';
 import { Application } from '../../declarations';
 import { Settings } from './settings.class';
@@ -8,7 +8,7 @@ import hooks from './settings.hooks';
 // Add this service to the service type index
 declare module '../../declarations' {
   interface ServiceTypes {
-    'api/v1/settings': Settings & ServiceAddons<any>;
+    'settings': Settings & ServiceAddons<any>;
   }
 
   interface SettingsData {
@@ -32,10 +32,10 @@ export default function (app: Application): void {
   };
 
   // Initialize our service with any options it requires
-  app.use('/api/v1/settings', new Settings(options, app));
+  app.use('/settings', new Settings(options, app));
 
   // Get our initialized service so that we can register hooks
-  const service = app.service('api/v1/settings');
+  const service = app.service('settings');
 
   service.hooks(hooks);
 }

--- a/server/src/services/views/views.class.ts
+++ b/server/src/services/views/views.class.ts
@@ -20,14 +20,14 @@ export class Views extends Service<ViewData> {
       await this.diffContentSlots(id as number, data.contentSlots);
     } else {
       // The content slots are intentionally left empty, remove all existing ones
-      await this.app.service('api/v1/content-slots').remove(null, { query: { viewId: id } });
+      await this.app.service('content-slots').remove(null, { query: { viewId: id } });
     }
 
     return await super._update(id, data, params);
   }
 
   private async diffContentSlots(id: number, submittedContentSlots: ContentSlotData[] | undefined) {
-    const ContentSlotsService = this.app.service('api/v1/content-slots');
+    const ContentSlotsService = this.app.service('content-slots');
 
     if (submittedContentSlots && submittedContentSlots.length === 0) {
       // Shortcut: No content slots should be assigned, so delete any that belong to this view

--- a/server/src/services/views/views.hooks.ts
+++ b/server/src/services/views/views.hooks.ts
@@ -8,7 +8,7 @@ const { authenticate } = authentication.hooks;
 
 const populateOptions = {
   include: {
-    service: 'api/v1/content-slots',
+    service: 'content-slots',
     nameAs: 'contentSlots',
     keyHere: 'id',
     keyThere: 'viewId',

--- a/server/src/services/views/views.service.ts
+++ b/server/src/services/views/views.service.ts
@@ -1,4 +1,4 @@
-// Initializes the `views` service on path `/api/v1/views`
+// Initializes the `views` service on path `/views`
 import { ServiceAddons } from '@feathersjs/feathers';
 import { Application } from '../../declarations';
 import { Views } from './views.class';
@@ -8,7 +8,7 @@ import hooks from './views.hooks';
 // Add this service to the service type index
 declare module '../../declarations' {
   interface ServiceTypes {
-    'api/v1/views': Views & ServiceAddons<any>;
+    'views': Views & ServiceAddons<any>;
   }
 
   interface ViewData {
@@ -32,10 +32,10 @@ export default function (app: Application): void {
   };
 
   // Initialize our service with any options it requires
-  app.use('/api/v1/views', new Views(options, app));
+  app.use('/views', new Views(options, app));
 
   // Get our initialized service so that we can register hooks
-  const service = app.service('api/v1/views');
+  const service = app.service('views');
 
   service.hooks(hooks);
 }

--- a/server/test/services/announcements.test.ts
+++ b/server/test/services/announcements.test.ts
@@ -7,7 +7,7 @@ describe('\'announcements\' service', () => {
   });
 
   it('registered the service', () => {
-    const service = app.service('api/v1/announcements');
+    const service = app.service('announcements');
     expect(service).toBeTruthy();
   });
 });

--- a/server/test/services/api-keys.test.ts
+++ b/server/test/services/api-keys.test.ts
@@ -7,7 +7,7 @@ describe('\'api-keys\' service', () => {
   });
 
   it('registered the service', () => {
-    const service = app.service('api/v1/api-keys');
+    const service = app.service('api-keys');
     expect(service).toBeTruthy();
   });
 });

--- a/server/test/services/content-slots.test.ts
+++ b/server/test/services/content-slots.test.ts
@@ -7,7 +7,7 @@ describe('\'content-slots\' service', () => {
   });
 
   it('registered the service', () => {
-    const service = app.service('api/v1/content-slots');
+    const service = app.service('content-slots');
     expect(service).toBeTruthy();
   });
 });

--- a/server/test/services/displays.test.ts
+++ b/server/test/services/displays.test.ts
@@ -1,6 +1,6 @@
 import app from '../../src/app';
 
-const servicePath = 'api/v1/displays';
+const servicePath = 'displays';
 
 describe('\'displays\' service', () => {
   beforeAll(done => {

--- a/server/test/services/incidents.test.ts
+++ b/server/test/services/incidents.test.ts
@@ -7,7 +7,7 @@ describe('\'incidents\' service', () => {
   });
 
   it('registered the service', () => {
-    const service = app.service('api/v1/incidents');
+    const service = app.service('incidents');
     expect(service).toBeTruthy();
   });
 });

--- a/server/test/services/key-requests.test.ts
+++ b/server/test/services/key-requests.test.ts
@@ -7,7 +7,7 @@ describe('\'key-requests\' service', () => {
   });
 
   it('registered the service', () => {
-    const service = app.service('api/v1/key-requests');
+    const service = app.service('key-requests');
     expect(service).toBeTruthy();
   });
 });

--- a/server/test/services/locations.test.ts
+++ b/server/test/services/locations.test.ts
@@ -7,7 +7,7 @@ describe('\'locations\' service', () => {
   });
 
   it('registered the service', () => {
-    const service = app.service('api/v1/locations');
+    const service = app.service('locations');
     expect(service).toBeTruthy();
   });
 });

--- a/server/test/services/settings.test.ts
+++ b/server/test/services/settings.test.ts
@@ -7,7 +7,7 @@ describe('\'settings\' service', () => {
   });
 
   it('registered the service', () => {
-    const service = app.service('api/v1/settings');
+    const service = app.service('settings');
     expect(service).toBeTruthy();
   });
 });

--- a/server/test/services/views.test.ts
+++ b/server/test/services/views.test.ts
@@ -7,7 +7,7 @@ describe('\'views\' service', () => {
   });
 
   it('registered the service', () => {
-    const service = app.service('api/v1/views');
+    const service = app.service('views');
     expect(service).toBeTruthy();
   });
 });

--- a/test-api/package-lock.json
+++ b/test-api/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@alarmdisplay/display-api-test",
       "version": "1.0.0",
       "devDependencies": {
-        "chai": "5.2.0",
-        "chai-http": "5.1.2",
+        "chai": "4.5.0",
+        "chai-http": "4.4.0",
         "mocha": "11.7.1"
       }
     },
@@ -65,6 +65,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -72,34 +79,25 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/methods": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
-      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
-      "version": "22.15.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
-      "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
+      "version": "24.0.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.7.tgz",
+      "integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/superagent": {
-      "version": "8.1.9",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
-      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.13.tgz",
+      "integrity": "sha512-YIGelp3ZyMiH0/A09PMAORO0EBGlF5xIKfDpK74wdYvWUs2o96b5CItJcWPdH409b7SAXIIG6p8NdU/4U2Maww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/cookiejar": "^2.1.5",
-        "@types/methods": "^1.1.4",
-        "@types/node": "*",
-        "form-data": "^4.0.0"
+        "@types/cookiejar": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/ansi-regex": {
@@ -146,13 +144,13 @@
       "license": "MIT"
     },
     "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": "*"
       }
     },
     "node_modules/asynckit": {
@@ -201,14 +199,14 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -231,39 +229,42 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
-      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=4"
       }
     },
     "node_modules/chai-http": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-5.1.2.tgz",
-      "integrity": "sha512-UFup7mUGkkjmi9bGA7F6vfp3lzGQZjtL//CEd+a4C+vlynSv756XHDUK8PoYk/UpTBBXqSghjQaJOUMUxJXNaA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-4.4.0.tgz",
+      "integrity": "sha512-uswN3rZpawlRaa5NiDUHcDZ3v2dw5QgLyAwnQ2tnVNuP7CwIsOFuYJ0xR1WiR7ymD4roBnJIzOUep7w9jQMFJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/superagent": "^8.1.7",
+        "@types/chai": "4",
+        "@types/superagent": "4.1.13",
         "charset": "^1.0.1",
         "cookiejar": "^2.1.4",
-        "is-ip": "^5.0.1",
+        "is-ip": "^2.0.0",
         "methods": "^1.1.2",
-        "qs": "^6.12.1",
-        "superagent": "^10.0.0"
+        "qs": "^6.11.2",
+        "superagent": "^8.0.9"
       },
       "engines": {
-        "node": ">=18.20.0"
+        "node": ">=10"
       }
     },
     "node_modules/chalk": {
@@ -307,13 +308,16 @@
       }
     },
     "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
       "engines": {
-        "node": ">= 16"
+        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -410,22 +414,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/clone-regexp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
-      "integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-regexp": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -465,19 +453,6 @@
       "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/convert-hrtime": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
-      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -536,11 +511,14 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -729,15 +707,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -745,18 +724,16 @@
       }
     },
     "node_modules/formidable": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
-      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -772,19 +749,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/function-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz",
-      "integrity": "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -793,6 +757,16 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -931,16 +905,13 @@
       }
     },
     "node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -954,20 +925,16 @@
       }
     },
     "node_modules/is-ip": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.1.tgz",
-      "integrity": "sha512-FCsGHdlrOnZQcp0+XT5a+pYowf33itBalCl+7ovNXC/7o5BhIpG14M3OrpPPdBSIQJCm+0M5+9mO7S9VVTTCFw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
+      "integrity": "sha512-9MTn0dteHETtyUx8pxqMwg5hMBi3pvlyglJ+b79KOCca0po23337LbVV2Hl4xmMvfw++ljnO0/+5G6G+0Szh6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
+        "ip-regex": "^2.0.0"
       },
       "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/is-plain-obj": {
@@ -978,19 +945,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-regexp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
-      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -1076,11 +1030,14 @@
       }
     },
     "node_modules/loupe": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
-      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -1314,13 +1271,13 @@
       }
     },
     "node_modules/pathval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14.16"
+        "node": "*"
       }
     },
     "node_modules/picocolors": {
@@ -1400,6 +1357,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
@@ -1640,28 +1610,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/super-regex": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
-      "integrity": "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone-regexp": "^3.0.0",
-        "function-timeout": "^0.1.0",
-        "time-span": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/superagent": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.1.tgz",
-      "integrity": "sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1670,13 +1623,14 @@
         "debug": "^4.3.4",
         "fast-safe-stringify": "^2.1.1",
         "form-data": "^4.0.0",
-        "formidable": "^3.5.4",
+        "formidable": "^2.1.2",
         "methods": "^1.1.2",
         "mime": "2.6.0",
-        "qs": "^6.11.0"
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=6.4.0 <13 || >=14"
       }
     },
     "node_modules/supports-color": {
@@ -1695,26 +1649,20 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/time-span": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
-      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "convert-hrtime": "^5.0.0"
-      },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
     },

--- a/test-api/package.json
+++ b/test-api/package.json
@@ -7,8 +7,8 @@
   },
   "author": "Andreas Brain",
   "devDependencies": {
-    "chai": "5.2.0",
-    "chai-http": "5.1.2",
+    "chai": "4.5.0",
+    "chai-http": "4.4.0",
     "mocha": "11.7.1"
   }
 }

--- a/test-api/spec/001-authentication/common.js
+++ b/test-api/spec/001-authentication/common.js
@@ -5,14 +5,14 @@ let should = chai.should();
 chai.use(chaiHttp);
 
 const basePaths = [
-  '/api/v1/announcements',
-  '/api/v1/api-keys',
-  '/api/v1/content-slots',
-  '/api/v1/displays',
-  '/api/v1/incidents',
-  '/api/v1/locations',
-  '/api/v1/settings',
-  '/api/v1/views',
+  '/announcements',
+  '/api-keys',
+  '/content-slots',
+  '/displays',
+  '/incidents',
+  '/locations',
+  '/settings',
+  '/views',
 ]
 
 describe('Authentication', function () {

--- a/test-api/spec/001-authentication/key-requests.js
+++ b/test-api/spec/001-authentication/key-requests.js
@@ -4,7 +4,7 @@ let should = chai.should();
 
 chai.use(chaiHttp);
 
-const basePath = '/api/v1/key-requests'
+const basePath = '/key-requests'
 describe(basePath, () => {
   describe('Authentication', () => {
     it(`GET ${basePath} should require authentication`, function (done) {


### PR DESCRIPTION
The prefix `api/v1/` should not be baked into the application. Also, the `users` service never had it, because this was not meant to be by the framework.

When the time comes, API versioning is probably realized by using Media Types.